### PR TITLE
Upgrade to `go 1.21` and add `toolchain go1.21.4`

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,10 +28,10 @@ jobs:
     - name: Set up Homebrew
       uses: Homebrew/actions/setup-homebrew@master
 
-    - name: Set up Go 1.19.x
+    - name: Set up Go 1.21.x
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.x
+        go-version: 1.21.x
 
     - name: Setup ko
       uses: imjasonh/setup-ko@v0.6

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ We persist the guardian if 5 min passed since we last persisted it and we have a
 
 Although **Guardian** CRDs and Configmaps can be controlled directly via `kubectl`, an optional [guard-ui](cmd/guard-ui) is offered to simplify and clarify the micro-rules.
 
-
 ## Summary
 
 Guard takes a zero-trust approach. Guard assumes that all services are most likely vulnerable and places a gate in front of every service to monitor client interactions and block exploit delivery. By doing so, Guard implements a zero-trust architecture. At the same time, guard monitors each service Pod, offering further protection on a Pod level basis.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ We persist the guardian if 5 min passed since we last persisted it and we have a
 
 Although **Guardian** CRDs and Configmaps can be controlled directly via `kubectl`, an optional [guard-ui](cmd/guard-ui) is offered to simplify and clarify the micro-rules.
 
+
 ## Summary
 
 Guard takes a zero-trust approach. Guard assumes that all services are most likely vulnerable and places a gate in front of every service to monitor client interactions and block exploit delivery. By doing so, Guard implements a zero-trust architecture. At the same time, guard monitors each service Pod, offering further protection on a Pod level basis.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/security-guard
 
-go 1.18
+go 1.21
 
 require (
 	github.com/emicklei/go-restful v2.9.5+incompatible

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module knative.dev/security-guard
 
 go 1.21
 
+toolchain go1.21.4
+
 require (
 	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/golang-jwt/jwt/v4 v4.4.3


### PR DESCRIPTION
This PR is used to upgrade to go 1.21 and add toolchain go1.21.4
To do so, the e2e tests go version should also be upgraded to go 1.21