### PR TITLE
Updated kind version

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,7 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
 
     - name: Set up Go 1.21.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21.x
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         k8s-version:
         - v1.30.x
-        - v1.29.x
+        - v1.31.x
 
     env:
       KO_DOCKER_REPO: registry.local:5000/knative # registry setup by setup-kind
@@ -29,7 +29,7 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
 
     - name: Set up Go 1.21.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: 1.21.x
 
@@ -40,7 +40,7 @@ jobs:
       run: brew install knative/client/kn
 
     - name: Check out current repository code onto GOPATH
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup KinD
       uses: chainguard-dev/actions/setup-kind@main

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.28.x
+        - v1.30.x
         - v1.29.x
 
     env:


### PR DESCRIPTION
Update workflow to use kind version 1.30, 1.31
Update to actions/setup-go@v4, actions/checkout@v4