### PR TITLE
Removed toolchain from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module knative.dev/security-guard
 
 go 1.23.0
 
-toolchain go1.23.3
-
 require (
 	github.com/emicklei/go-restful v2.9.5+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0


### PR DESCRIPTION
Removed toolchain from go.mod

Hoping to fix errors during auto-update of Deps and Codegen:
https://github.com/knative-extensions/knobots/actions/runs/13308346547/job/37164471762#step:6:540

